### PR TITLE
[feat] 운영 서버 DB Flyway 마이그레이션 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,10 @@ dependencies {
     implementation 'com.h2database:h2:2.2.220'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
+
+    // flyway
+    implementation 'org.flywaydb:flyway-core'
+    implementation "org.flywaydb:flyway-mysql"
 }
 
 // plain jar 생성 X 설정

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -16,6 +16,13 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect
     show_sql: false        # prod 환경에서는 SQL 출력 비활성화
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    table: _flyway_schema_history
+    baseline-on-migrate: true
+    baseline-version: 1        # 베이스라인으로 간주할 버전(V1)
+    # 추후 baseline-on-migrate: false
   data:
     redis:
       host: redis

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -11,7 +11,7 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: update       # 추후 validate
+      ddl-auto: validate
     properties:
       hibernate:
         dialect: org.hibernate.dialect.MySQL8Dialect

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,6 +16,8 @@ spring:
         dialect: org.hibernate.dialect.MySQL8Dialect
         format_sql: true
     show_sql: true
+  flyway:
+    enabled: false
   springdoc:
     api-docs:
       enabled: true

--- a/src/main/resources/db/migration/V1__Initial_Set.sql
+++ b/src/main/resources/db/migration/V1__Initial_Set.sql
@@ -1,0 +1,135 @@
+create table room
+(
+    room_id   bigint auto_increment
+        primary key,
+    name      varchar(50) not null,
+    master_id bigint      not null
+);
+
+create table place
+(
+    id         bigint auto_increment
+        primary key,
+    address    varchar(255) null,
+    latitude   double       not null,
+    longitude  double       not null,
+    place_name varchar(255) not null,
+    room_id    bigint       not null,
+    constraint FKn5fooimfmfn3cr1jcl1ynqlo4
+        foreign key (room_id) references room (room_id)
+);
+
+create table trip_plans
+(
+    id              bigint auto_increment
+        primary key,
+    created_at      datetime(6)                                                         null,
+    deleted_at      datetime(6)                                                         null,
+    updated_at      datetime(6)                                                         null,
+    description     varchar(255)                                                        null,
+    end_date        date                                                                not null,
+    group_name      varchar(255)                                                        null,
+    image_url       varchar(255)                                                        null,
+    location        varchar(50)                                                         not null,
+    max_days        int                                                                 null,
+    min_days        int                                                                 null,
+    name            varchar(50)                                                         not null,
+    price           varchar(255)                                                        null,
+    start_date      date                                                                not null,
+    status          enum ('COMPLETED', 'ONGOING', 'PLANNED')                            not null,
+    trip_plan_type  enum ('COURSE', 'SCHEDULE')                                         not null,
+    trip_type       enum ('DOMESTIC', 'OVERSEAS')                                       not null,
+    vote_limit_time enum ('FOUR_HOURS', 'SIXTY_MINUTES', 'SIX_HOURS', 'THIRTY_MINUTES') null,
+    room_id         bigint                                                              not null,
+    user_id         bigint                                                              not null,
+    vote_room_id    bigint                                                              null,
+    constraint UK42k9hoe33eigk91y0p30g7pa1
+        unique (vote_room_id),
+    constraint FKja2tkp5xgslubitx3tjg7hyvk
+        foreign key (room_id) references room (room_id)
+);
+
+create table vote_room
+(
+    id           bigint auto_increment
+        primary key,
+    created_at   datetime(6) null,
+    deleted_at   datetime(6) null,
+    updated_at   datetime(6) null,
+    trip_plan_id bigint      not null,
+    constraint UKcbeshvvejgwid80yuk6w3be61
+        unique (trip_plan_id),
+    constraint FKgc9mle9f41mxuxlol4i6rkwma
+        foreign key (trip_plan_id) references trip_plans (id)
+);
+
+alter table trip_plans
+    add constraint FKdkhe8451e74bkdthruplc1muu
+        foreign key (vote_room_id) references vote_room (id);
+
+create table vote
+(
+    id           bigint auto_increment
+        primary key,
+    created_at   datetime(6)          null,
+    deleted_at   datetime(6)          null,
+    updated_at   datetime(6)          null,
+    type         enum ('BAD', 'GOOD') not null,
+    trip_plan_id bigint               not null,
+    vote_room_id bigint               not null,
+    constraint FK6c963w1o9pwo0quv7yn0pvcgy
+        foreign key (trip_plan_id) references trip_plans (id),
+    constraint FK7u3cnhrdhm9ky4tpudlripwt
+        foreign key (vote_room_id) references vote_room (id)
+);
+
+create table users
+(
+    user_id       bigint auto_increment
+        primary key,
+    created_at    datetime(6)  null,
+    deleted_at    datetime(6)  null,
+    updated_at    datetime(6)  null,
+    access_token  varchar(255) null,
+    email         varchar(255) not null,
+    profile_image varchar(255) null,
+    refresh_token varchar(255) null,
+    username      varchar(255) null,
+    vote_id       bigint       null,
+    constraint UK6dotkott2kjsp8vw4d0m25fb7
+        unique (email),
+    constraint FKl1vjmgij3ildpydw36401sbbw
+        foreign key (vote_id) references vote (id)
+);
+
+alter table room
+    add constraint FKhm55owuj9qgvc3hm9ikcd8kw5
+        foreign key (master_id) references users (user_id);
+
+create table room_member
+(
+    room_id bigint not null,
+    user_id bigint not null,
+    primary key (room_id, user_id),
+    constraint FK1d9bddturxgt7hws5r59wirw8
+        foreign key (user_id) references users (user_id),
+    constraint FKlmp67erahqx7u5shbkc12p0lw
+        foreign key (room_id) references room (room_id)
+);
+
+alter table trip_plans
+    add constraint FKbmly4beva2ojcevvinyll1ccw
+        foreign key (user_id) references users (user_id);
+
+create table user_images
+(
+    id        bigint auto_increment
+        primary key,
+    image_url varchar(255) not null,
+    user_id   bigint       not null,
+    constraint UK17d6602b98y1l3ee0cqk320mi
+        unique (user_id),
+    constraint FKl1lf9kxrd8ybmovqsxcuxhw42
+        foreign key (user_id) references users (user_id)
+);
+


### PR DESCRIPTION
## #️⃣연관된 이슈

> #36 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

JPA Hibernate 의 ddl-auto 는 validate 로 검증 용도로만 사용하고,
migration 라이브러리인 Flyway를 사용해서 운영 DB를 관리할 예정입니다.

스프링에서 RDS로 직접 접근을 못하게 막아놨기에, 머지 후 EC2에서 테스트 하겠습니다.

[머지 후 테스트 결과 ] 
<img width="1308" alt="image" src="https://github.com/user-attachments/assets/d8499855-0aea-4e7f-b9fa-999ea8b30ffd" />

[EC2 Docker 환경 내부 RDS 테이블 생성 결과]
<img width="472" alt="image" src="https://github.com/user-attachments/assets/75821a07-ee5e-4a8d-8a2a-fbfb2a7c481b" />



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
