### PR TITLE
[fix] 투표방 생성 API 로직 수정

### DIFF
--- a/src/main/java/com/umc/yeogi_gal_lae/api/tripPlan/domain/TripPlan.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/api/tripPlan/domain/TripPlan.java
@@ -42,24 +42,10 @@ public class TripPlan extends BaseEntity {
     @Column
     private VoteLimitTime voteLimitTime;
 
-//    @Enumerated(EnumType.STRING)
-//    @Column
-//    private Accommodation accommodation;
-//
-//    @Enumerated(EnumType.STRING)
-//    @Column
-//    private Meal meal;
-//
-//    @Enumerated(EnumType.STRING)
-//    @Column
-//    private Transportation transportation;
-
-
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     @Builder.Default
     private Status status = Status.PLANNED;     // 기본값 설정
-
 
     @Column(nullable = false, length = 50)
     private String location;
@@ -91,7 +77,7 @@ public class TripPlan extends BaseEntity {
     @JoinColumn(name = "room_id", nullable = false) // 방 ID를 외래 키로 설정
     private Room room; // 여행 계획이 속한 방
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, optional = true)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST, optional = true)
     @JoinColumn(name = "vote_room_id", nullable = true)
     private VoteRoom voteRoom;
 

--- a/src/main/java/com/umc/yeogi_gal_lae/api/vote/repository/VoteRoomRepository.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/api/vote/repository/VoteRoomRepository.java
@@ -2,6 +2,8 @@ package com.umc.yeogi_gal_lae.api.vote.repository;
 
 import com.umc.yeogi_gal_lae.api.vote.domain.VoteRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -9,5 +11,10 @@ public interface VoteRoomRepository extends JpaRepository<VoteRoom,Long> {
 
     Optional<VoteRoom> findVoteRoomByTripPlanId(Long tripId);
 
-    Optional<VoteRoom> findByTripPlanId(Long id);
+//    Optional<VoteRoom> findByTripPlanId(Long id);
+
+//    Optional<VoteRoom> findByTripPlanId(Long tripPlanId);
+
+    @Query("SELECT vr FROM VoteRoom vr WHERE vr.tripPlan.id = :tripPlanId")
+    Optional<VoteRoom> findByTripPlanId(@Param("tripPlanId") Long tripPlanId);
 }

--- a/src/main/java/com/umc/yeogi_gal_lae/api/vote/service/VoteService.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/api/vote/service/VoteService.java
@@ -36,20 +36,24 @@ public class VoteService {
     private final VoteRoomRepository voteRoomRepository;
 
     @Transactional
-    public void createVoteRoom(VoteRequest.createVoteRoomReq request) {
-
+    public synchronized void createVoteRoom(VoteRequest.createVoteRoomReq request) {
+        // 1. 여행 계획 ID로 TripPlan 조회
         TripPlan tripPlan = tripPlanRepository.findById(request.getTripId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.TRIP_PLAN_NOT_FOUND));
 
+        // 2. 기존 VoteRoom이 존재하는지 확인 (중복 생성 방지)
+        if (voteRoomRepository.findByTripPlanId(tripPlan.getId()).isPresent()) {
+            throw new BusinessException(ErrorCode.VOTE_ROOM_ALREADY_EXISTS);
+        }
+
+        // 3. 새로운 VoteRoom 생성 및 저장
         VoteRoom voteRoom = new VoteRoom();
-
         voteRoom.setTripPlan(tripPlan);
-        tripPlan.setStatus(Status.ONGOING);        // tripPlan status 값  변경
+        tripPlan.setStatus(Status.ONGOING); // 여행 계획을 '진행 중' 상태로 변경
 
-        tripPlanRepository.save(tripPlan);
         voteRoomRepository.save(voteRoom);
+        tripPlanRepository.save(tripPlan);
     }
-
 
     @Transactional
     public void createVote(VoteRequest.createVoteReq request, String userEmail){

--- a/src/main/java/com/umc/yeogi_gal_lae/global/error/ErrorCode.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/global/error/ErrorCode.java
@@ -57,7 +57,11 @@ public enum ErrorCode implements BaseStatus {
     DATE_ERROR(HttpStatus.BAD_REQUEST, "DATE_401", "적절한 날짜 선택이 아닙니다."),
 
     // 서버 오류 코드
-    AI_TRIP_PLAN_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "50001", "여행 일정 생성에 실패했습니다.");;
+    AI_TRIP_PLAN_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "50001", "여행 일정 생성에 실패했습니다."),
+
+    // 투표방 오류
+    VOTE_ROOM_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "VOTE_400", "이미 존재하는 투표 방입니다.")
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
## #️⃣연관된 이슈


#### VoteRoom중복생성버그수정
## 📝작업 내용
****
> VoteRoom이 중복 생성되는 이슈를 해결하였습니다.  
> 동일한 TripPlan에 대해 두 개 이상의 VoteRoom이 생성되지 않도록 동시성 문제를 해결하고, `findByTripPlanId()`의 동작을 개선하였습니다.

1. **중복 검증 로직 보강 (`createVoteRoom()`)**
   - 기존 `findByTripPlanId()` 메서드가 중복 검사를 수행하지 못하는 경우가 발생하여, **명확한 조회를 위한 JPQL을 적용**하였습니다.
   - `synchronized` 키워드를 추가하여 **동시에 여러 요청이 들어와도 중복 삽입을 방지**하였습니다.

2. **VoteRoomRepository의 `findByTripPlanId()` 개선**
   ```java
   @Query("SELECT vr FROM VoteRoom vr WHERE vr.tripPlan.id = :tripPlanId")
   Optional<VoteRoom> findByTripPlanId(@Param("tripPlanId") Long tripPlanId);
   ```
- 기존 메서드가 예상대로 작동하지 않는 경우가 있어, JPQL을 이용한 명확한 조회로 변경하였습니다.
3. **TripPlan 엔티티의 CascadeType.ALL을 CascadeType.PERSIST로 변경**
    ```java
    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST, optional = true)
    @JoinColumn(name = "vote_room_id", nullable = true)
    private VoteRoom voteRoom;
    ```
4. **createVoteRoom() 내 동시성 처리 추가**
    ```java
        @Transactional
    public synchronized void createVoteRoom(VoteRequest.createVoteRoomReq request) {
        TripPlan tripPlan = tripPlanRepository.findById(request.getTripId())
                .orElseThrow(() -> new BusinessException(ErrorCode.TRIP_PLAN_NOT_FOUND));
    
        if (voteRoomRepository.findByTripPlanId(tripPlan.getId()).isPresent()) {
            throw new BusinessException(ErrorCode.VOTE_ROOM_ALREADY_EXISTS);
        }
    
        VoteRoom voteRoom = new VoteRoom();
        voteRoom.setTripPlan(tripPlan);
        tripPlan.setStatus(Status.ONGOING);
    
        voteRoomRepository.save(voteRoom);
        tripPlanRepository.save(tripPlan);
    }
    ```
- 동시성 문제를 방지하기 위해 synchronized 키워드를 추가하여 중복 요청이 들어와도 동일한 TripPlan에 대해 두 개의 VoteRoom이 생성되지 않도록 보장함.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
> 