### PR TITLE
[feat] & [refactor] 알림 읽음 여부 구현 및 api 요청 방식 수정

### DIFF
--- a/src/main/java/com/umc/yeogi_gal_lae/api/home/controller/HomeController.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/api/home/controller/HomeController.java
@@ -34,4 +34,10 @@ public class HomeController {
     public Response<HomeResponse.CompletedTripPlanList> getCompletedTripPlans(@RequestParam String userEmail) {
         return homeService.getCompletedTripPlans(userEmail);
     }
+
+    @Operation(summary = "홈 화면 알림 확인 여부", description = "특정 사용자가 읽지 않은 알림이 있는지 여부를 반환합니다.")
+    @GetMapping("/notification-status")
+    public Response<HomeResponse.NotificationStatus> getNotificationStatus(@RequestParam String userEmail) {
+        return homeService.getNotificationStatus(userEmail);
+    }
 }

--- a/src/main/java/com/umc/yeogi_gal_lae/api/home/controller/HomeController.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/api/home/controller/HomeController.java
@@ -2,6 +2,7 @@ package com.umc.yeogi_gal_lae.api.home.controller;
 
 import com.umc.yeogi_gal_lae.api.home.dto.HomeResponse;
 import com.umc.yeogi_gal_lae.api.home.service.HomeService;
+import com.umc.yeogi_gal_lae.api.vote.AuthenticatedUserUtils;
 import com.umc.yeogi_gal_lae.global.common.response.Response;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -19,25 +20,29 @@ public class HomeController {
 
     @Operation(summary = "진행 중인 투표방 조회", description = "사용자가 속한 진행 중인 투표방과 개수를 조회합니다.")
     @GetMapping("/ongoing-vote-rooms")
-    public Response<HomeResponse.OngoingVoteRoomList> getOngoingVoteRooms(@RequestParam String userEmail) {
+    public Response<HomeResponse.OngoingVoteRoomList> getOngoingVoteRooms() {
+        String userEmail = AuthenticatedUserUtils.getAuthenticatedUserEmail();
         return homeService.getOngoingVoteRooms(userEmail);
     }
 
     @Operation(summary = "완료된 투표 기반 예정된 여행 조회", description = "완료된 투표 상태의 여행 중 종료 날짜가 현재 시간과 같거나 미래인 여행들을 조회합니다.")
     @GetMapping("/completed-vote-rooms")
-    public Response<HomeResponse.CompletedVoteRoomList> getCompletedVoteRooms(@RequestParam String userEmail) {
+    public Response<HomeResponse.CompletedVoteRoomList> getCompletedVoteRooms() {
+        String userEmail = AuthenticatedUserUtils.getAuthenticatedUserEmail();
         return homeService.getFutureVoteBasedTrips(userEmail);
     }
 
     @Operation(summary = "완료된 여행 계획 조회", description = "사용자가 속한 완료된 여행 계획과 개수를 조회합니다.")
     @GetMapping("/completed-trip-plans")
-    public Response<HomeResponse.CompletedTripPlanList> getCompletedTripPlans(@RequestParam String userEmail) {
+    public Response<HomeResponse.CompletedTripPlanList> getCompletedTripPlans() {
+        String userEmail = AuthenticatedUserUtils.getAuthenticatedUserEmail();
         return homeService.getCompletedTripPlans(userEmail);
     }
 
     @Operation(summary = "홈 화면 알림 확인 여부", description = "특정 사용자가 읽지 않은 알림이 있는지 여부를 반환합니다.")
     @GetMapping("/notification-status")
-    public Response<HomeResponse.NotificationStatus> getNotificationStatus(@RequestParam String userEmail) {
+    public Response<HomeResponse.NotificationStatus> getNotificationStatus() {
+        String userEmail = AuthenticatedUserUtils.getAuthenticatedUserEmail();
         return homeService.getNotificationStatus(userEmail);
     }
 }

--- a/src/main/java/com/umc/yeogi_gal_lae/api/home/dto/HomeResponse.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/api/home/dto/HomeResponse.java
@@ -65,4 +65,10 @@ public class HomeResponse {
         private int totalCount;
         private List<CompletedTripPlan> trips;
     }
+
+    @Getter
+    @AllArgsConstructor
+    public static class NotificationStatus {
+        private boolean hasUnreadNotifications;
+    }
 }

--- a/src/main/java/com/umc/yeogi_gal_lae/api/home/service/HomeService.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/api/home/service/HomeService.java
@@ -3,6 +3,7 @@ package com.umc.yeogi_gal_lae.api.home.service;
 import com.umc.yeogi_gal_lae.api.home.converter.HomeConverter;
 import com.umc.yeogi_gal_lae.api.home.dto.HomeResponse;
 import com.umc.yeogi_gal_lae.api.home.repository.HomeRepository;
+import com.umc.yeogi_gal_lae.api.notification.service.NotificationService;
 import com.umc.yeogi_gal_lae.api.room.repository.RoomMemberRepository;
 import com.umc.yeogi_gal_lae.api.tripPlan.domain.TripPlan;
 import com.umc.yeogi_gal_lae.api.tripPlan.types.Status;
@@ -28,6 +29,7 @@ public class HomeService {
     private final HomeRepository homeRepository;
     private final RoomMemberRepository roomMemberRepository;
     private final UserRepository userRepository;
+    private final NotificationService notificationService;
 
     public Response<HomeResponse.OngoingVoteRoomList> getOngoingVoteRooms(String userEmail) {
         User user = userRepository.findByEmail(userEmail)
@@ -97,5 +99,13 @@ public class HomeService {
         LocalDateTime voteEndTime = voteRoom.getCreatedAt().plusSeconds(tripPlan.getVoteLimitTime().getSeconds());
 
         return LocalDateTime.now().isAfter(voteEndTime);
+    }
+
+    /**
+     * 특정 사용자의 읽지 않은 알림 여부 반환 (이메일 기반)
+     */
+    public Response<HomeResponse.NotificationStatus> getNotificationStatus(String userEmail) {
+        boolean hasUnreadNotifications = notificationService.hasUnreadNotifications(userEmail);
+        return Response.of(SuccessCode.NOTIFICATION_FETCH_OK, new HomeResponse.NotificationStatus(hasUnreadNotifications));
     }
 }

--- a/src/main/java/com/umc/yeogi_gal_lae/api/notification/controller/NotificationController.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/api/notification/controller/NotificationController.java
@@ -25,8 +25,9 @@ public class NotificationController {
     public ResponseEntity<Response<Void>> createStartNotification(
             @RequestParam String roomName,
             @RequestParam String userName,
+            @RequestParam String userEmail,
             @RequestParam NotificationType type) {
-        notificationService.createStartNotification(roomName, userName, type);
+        notificationService.createStartNotification(roomName, userName, userEmail, type);
         return ResponseEntity.ok(Response.of(SuccessCode.NOTIFICATION_START_OK));
     }
 
@@ -36,8 +37,9 @@ public class NotificationController {
     @PostMapping("/end")
     public ResponseEntity<Response<Void>> createEndNotification(
             @RequestParam String roomName,
+            @RequestParam String userEmail,
             @RequestParam NotificationType type) {
-        notificationService.createEndNotification(roomName, type);
+        notificationService.createEndNotification(roomName, userEmail, type);
         return ResponseEntity.ok(Response.of(SuccessCode.NOTIFICATION_END_OK));
     }
 
@@ -48,5 +50,16 @@ public class NotificationController {
     public ResponseEntity<Response<List<NotificationDto>>> getAllNotifications() {
         List<NotificationDto> notifications = notificationService.getAllNotifications();
         return ResponseEntity.ok(Response.of(SuccessCode.NOTIFICATION_FETCH_OK, notifications));
+    }
+
+    /**
+     * 특정 알림 읽음 처리
+     */
+    @PatchMapping("/{id}/read")
+    public ResponseEntity<Response<Void>> markNotificationAsRead(
+        @PathVariable Long id,
+        @RequestParam String userEmail) {
+        notificationService.markNotificationAsRead(id, userEmail);
+        return ResponseEntity.ok(Response.of(SuccessCode.NOTIFICATION_READ_OK));
     }
 }

--- a/src/main/java/com/umc/yeogi_gal_lae/api/notification/controller/NotificationController.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/api/notification/controller/NotificationController.java
@@ -3,6 +3,7 @@ package com.umc.yeogi_gal_lae.api.notification.controller;
 import com.umc.yeogi_gal_lae.api.notification.dto.NotificationDto;
 import com.umc.yeogi_gal_lae.api.notification.service.NotificationService;
 import com.umc.yeogi_gal_lae.api.notification.domain.NotificationType;
+import com.umc.yeogi_gal_lae.api.vote.AuthenticatedUserUtils;
 import com.umc.yeogi_gal_lae.global.common.response.Response;
 import com.umc.yeogi_gal_lae.global.success.SuccessCode;
 import lombok.RequiredArgsConstructor;
@@ -57,8 +58,8 @@ public class NotificationController {
      */
     @PatchMapping("/{id}/read")
     public ResponseEntity<Response<Void>> markNotificationAsRead(
-        @PathVariable Long id,
-        @RequestParam String userEmail) {
+        @PathVariable Long id) {
+        String userEmail = AuthenticatedUserUtils.getAuthenticatedUserEmail();
         notificationService.markNotificationAsRead(id, userEmail);
         return ResponseEntity.ok(Response.of(SuccessCode.NOTIFICATION_READ_OK));
     }

--- a/src/main/java/com/umc/yeogi_gal_lae/api/notification/controller/NotificationController.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/api/notification/controller/NotificationController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/notifications")
+@RequestMapping("/api/notifications")
 @RequiredArgsConstructor
 public class NotificationController {
 

--- a/src/main/java/com/umc/yeogi_gal_lae/api/notification/domain/Notification.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/api/notification/domain/Notification.java
@@ -17,10 +17,18 @@ public class Notification extends BaseEntity {
 
     private String roomName; // 방 이름
     private String userName; // 사용자 이름 (시작 알림에만 필요)
+    private String userEmail; // 사용자 이메일 추가 (중복 문제 해결)
 
     @Enumerated(EnumType.STRING)
     private NotificationType type;
 
+    @Column(nullable = false)
+    private boolean isRead = false;
+
     private String content; // 알림 내용
 
+    // 특정 알림을 읽음 처리
+    public void markAsRead() {
+        this.isRead = true;
+    }
 }

--- a/src/main/java/com/umc/yeogi_gal_lae/api/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/api/notification/repository/NotificationRepository.java
@@ -1,10 +1,18 @@
 package com.umc.yeogi_gal_lae.api.notification.repository;
 
 import com.umc.yeogi_gal_lae.api.notification.domain.Notification;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     // 최신순 정렬
     List<Notification> findAllByOrderByCreatedAtDesc();
+
+    Optional<Notification> findById(Long id);
+
+    @Query("SELECT COUNT(n) FROM Notification n WHERE n.isRead = false AND n.userEmail = :userEmail")
+    long countUnreadNotificationsByUser(@Param("userEmail") String userEmail);
 }

--- a/src/main/java/com/umc/yeogi_gal_lae/api/notification/service/NotificationService.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/api/notification/service/NotificationService.java
@@ -4,6 +4,8 @@ import com.umc.yeogi_gal_lae.api.notification.dto.NotificationDto;
 import com.umc.yeogi_gal_lae.api.notification.domain.Notification;
 import com.umc.yeogi_gal_lae.api.notification.domain.NotificationType;
 import com.umc.yeogi_gal_lae.api.notification.repository.NotificationRepository;
+import com.umc.yeogi_gal_lae.global.error.BusinessException;
+import com.umc.yeogi_gal_lae.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,25 +23,26 @@ public class NotificationService {
      * 시작 알림 생성
      */
     @Transactional
-    public void createStartNotification(String roomName, String userName, NotificationType type) {
-        saveNotification(roomName, userName, type, true);
+    public void createStartNotification(String roomName, String userName, String userEmail, NotificationType type) {
+        saveNotification(roomName, userName, userEmail, type, true);
     }
 
     /**
      * 종료 알림 생성
      */
     @Transactional
-    public void createEndNotification(String roomName, NotificationType type) {
-        saveNotification(roomName, null, type, false);
+    public void createEndNotification(String roomName, String userEmail, NotificationType type) {
+        saveNotification(roomName, null, userEmail, type, false);
     }
 
     /**
      * 공통적으로 Notification 객체를 생성하여 저장하는 메서드
      */
-    private void saveNotification(String roomName, String userName, NotificationType type, boolean isStart) {
+    private void saveNotification(String roomName, String userName, String userEmail, NotificationType type, boolean isStart) {
         Notification notification = new Notification();
         notification.setRoomName(roomName);
         notification.setUserName(userName);
+        notification.setUserEmail(userEmail); // 이메일 저장
         notification.setType(type);
         notification.setContent(generateCaption(roomName, userName, type, isStart));
 
@@ -74,5 +77,30 @@ public class NotificationService {
         } else {
             return String.format("%s 방의 %s 확인해보세요!", roomName, type.getKorean());
         }
+    }
+
+    /**
+     *  특정 알림 읽음 처리
+     */
+    @Transactional
+    public void markNotificationAsRead(Long notificationId, String userEmail) {
+        Notification notification = notificationRepository.findById(notificationId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+        // 현재 로그인한 사용자의 이메일과 알림 수신자의 이메일 비교
+        if (!notification.getUserEmail().equals(userEmail)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN); // 403 FORBIDDEN
+        }
+
+        notification.markAsRead();
+        notificationRepository.save(notification);
+    }
+
+    /**
+     *  특정 사용자의 읽지 않은 알림 개수 조회 (이메일 기반)
+     */
+    @Transactional(readOnly = true)
+    public boolean hasUnreadNotifications(String userEmail) {
+        return notificationRepository.countUnreadNotificationsByUser(userEmail) > 0;
     }
 }

--- a/src/main/java/com/umc/yeogi_gal_lae/api/tripPlan/controller/TripPlanController.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/api/tripPlan/controller/TripPlanController.java
@@ -4,6 +4,7 @@ import com.umc.yeogi_gal_lae.api.tripPlan.dto.TripPlanRequest;
 import com.umc.yeogi_gal_lae.api.tripPlan.dto.TripPlanResponse;
 import com.umc.yeogi_gal_lae.api.tripPlan.service.TripPlanService;
 import com.umc.yeogi_gal_lae.api.tripPlan.types.TripPlanType;
+import com.umc.yeogi_gal_lae.api.vote.AuthenticatedUserUtils;
 import com.umc.yeogi_gal_lae.global.common.response.Response;
 import com.umc.yeogi_gal_lae.global.success.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
@@ -28,7 +29,12 @@ public class TripPlanController {
         @PathVariable TripPlanType tripPlanType,
         @RequestBody TripPlanRequest request) {
 
-        TripPlanResponse response = tripPlanService.createTripPlan(request, request.getUserId(), request.getRoomId(), tripPlanType);
+        // 현재 로그인한 사용자의 이메일 조회
+        String userEmail = AuthenticatedUserUtils.getAuthenticatedUserEmail();
+
+        // TripPlan 생성 (userId는 내부적으로 처리)
+        TripPlanResponse response = tripPlanService.createTripPlan(request, userEmail, request.getRoomId(), tripPlanType);
+
         return Response.of(SuccessCode.TRIP_PLAN_CREATED_OK, response);
     }
 

--- a/src/main/java/com/umc/yeogi_gal_lae/api/tripPlan/dto/TripPlanRequest.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/api/tripPlan/dto/TripPlanRequest.java
@@ -15,8 +15,7 @@ public class TripPlanRequest {
     private VoteLimitTime voteLimitTime; // "30분", "60분", "4시간", "6시간"
     private Integer minDays; // 최소 숙박일
     private Integer maxDays; // 최대 숙박일
-    private Long userId; // 유저 ID
-    private Long roomId; // 방 ID 추가
+    private Long roomId;
     private String imageUrl;
 
     // 이너 클래스 정의

--- a/src/main/java/com/umc/yeogi_gal_lae/api/tripPlan/service/TripPlanService.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/api/tripPlan/service/TripPlanService.java
@@ -8,10 +8,14 @@ import com.umc.yeogi_gal_lae.api.tripPlan.domain.TripPlan;
 import com.umc.yeogi_gal_lae.api.tripPlan.dto.TripPlanRequest;
 import com.umc.yeogi_gal_lae.api.tripPlan.dto.TripPlanResponse;
 import com.umc.yeogi_gal_lae.api.tripPlan.repository.TripPlanRepository;
+import com.umc.yeogi_gal_lae.api.tripPlan.types.Status;
 import com.umc.yeogi_gal_lae.api.tripPlan.types.TripPlanType;
 import com.umc.yeogi_gal_lae.api.user.domain.User;
 import com.umc.yeogi_gal_lae.api.user.repository.UserRepository;
+import com.umc.yeogi_gal_lae.api.vote.domain.VoteRoom;
+import com.umc.yeogi_gal_lae.api.vote.repository.VoteRoomRepository;
 import com.umc.yeogi_gal_lae.global.error.BusinessException;
+import com.umc.yeogi_gal_lae.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,25 +28,31 @@ import static com.umc.yeogi_gal_lae.global.error.ErrorCode.*;
 @RequiredArgsConstructor
 public class TripPlanService {
     private final TripPlanRepository tripPlanRepository;
+    private final VoteRoomRepository voteRoomRepository;
     private final UserRepository userRepository;
     private final RoomRepository roomRepository;
 
     @Transactional
-    public TripPlanResponse createTripPlan(TripPlanRequest request, Long userId, Long roomId, TripPlanType tripPlanType) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
+    public TripPlanResponse createTripPlan(TripPlanRequest request, String userEmail, Long roomId,
+        TripPlanType tripPlanType) {
+
+        User user = userRepository.findByEmail(userEmail)
+            .orElseThrow(() -> new BusinessException(USER_NOT_FOUND));
 
         Room room = roomRepository.findById(roomId)
-                .orElseThrow(() -> new BusinessException(ROOM_NOT_FOUND));
+            .orElseThrow(() -> new BusinessException(ROOM_NOT_FOUND));
 
         // 여행 계획 관련 검증 로직 호출
         validateTripPlanDays(request.getMinDays(), request.getMaxDays());
 
-        TripPlan tripPlan = TripPlanConverter.toEntity(request, user, room, room.getName(), tripPlanType);
+        TripPlan tripPlan = TripPlanConverter.toEntity(request, user, room, room.getName(),
+            tripPlanType);
         tripPlanRepository.save(tripPlan);
 
         // 방 멤버들에게 투표 연결
         linkTripPlanToRoomMembers(tripPlan, room);
+
+        createVoteRoomForTrip(tripPlan);
 
         return TripPlanConverter.toResponse(tripPlan);
     }
@@ -66,6 +76,30 @@ public class TripPlanService {
         if (members == null || members.isEmpty()) {
             throw new BusinessException(ROOM_MEMBER_NOT_EXIST);
         }
+    }
+
+    /**
+     * 🚀 여행 계획이 생성되면 자동으로 투표방을 생성하는 메서드
+     */
+    private void createVoteRoomForTrip(TripPlan tripPlan) {
+        // 기존에 존재하는 투표방이 있는지 확인 (중복 생성 방지)
+        if (voteRoomRepository.findByTripPlanId(tripPlan.getId()).isPresent()) {
+            throw new BusinessException(ErrorCode.VOTE_ROOM_ALREADY_EXISTS);
+        }
+
+        // 새로운 투표방 생성
+        VoteRoom voteRoom = VoteRoom.builder()
+            .tripPlan(tripPlan)
+            .build();
+
+        // 여행 계획과 투표방을 서로 연결
+        voteRoom.setTripPlan(tripPlan);
+        tripPlan.setVoteRoom(voteRoom);
+        tripPlan.setStatus(Status.ONGOING); // 여행 계획 상태를 '진행 중'으로 변경
+
+        // 저장
+        voteRoomRepository.save(voteRoom);
+        tripPlanRepository.save(tripPlan);
     }
 }
 

--- a/src/main/java/com/umc/yeogi_gal_lae/api/vote/controller/VoteController.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/api/vote/controller/VoteController.java
@@ -32,17 +32,6 @@ public class VoteController {
     private final ValidVoteResultService validVoteResultService;
 
     @Validated
-    @Operation(summary = "투표방 생성 API", description = "등록된 여행 계획에 대한 투표방을 생성합니다.")
-    @PostMapping("/vote/new-room")
-    public Response<Void> createVoteRoom(@RequestBody @Valid VoteRequest.createVoteRoomReq voteRequest) {
-
-        voteService.createVoteRoom(voteRequest);
-
-        return Response.of(SuccessCode.VOTE_ROOM_CREATED_OK);
-    }
-
-
-    @Validated
     @Operation(summary = "투표 API", description = "현재 사용자의 투표 요청 입니다.")
     @PostMapping("/vote")
     public Response<Void> createVote(@RequestBody @Valid VoteRequest.createVoteReq voteRequest) {

--- a/src/main/java/com/umc/yeogi_gal_lae/api/vote/service/ValidVoteResultService.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/api/vote/service/ValidVoteResultService.java
@@ -66,7 +66,7 @@ public class ValidVoteResultService {
             String roomName = room.getName();
 
             // 투표 완료 알림 생성
-            notificationService.createEndNotification(roomName, NotificationType.VOTE_COMPLETE);
+            notificationService.createEndNotification(roomName, tripPlan.getUser().getEmail(), NotificationType.VOTE_COMPLETE);
             return true;
         }
         else{
@@ -78,7 +78,7 @@ public class ValidVoteResultService {
             String roomName = room.getName();
 
             // 투표 완료 알림 생성
-            notificationService.createEndNotification(roomName, NotificationType.VOTE_COMPLETE);
+            notificationService.createEndNotification(roomName, tripPlan.getUser().getEmail(), NotificationType.VOTE_COMPLETE);
             return false;
         }
 

--- a/src/main/java/com/umc/yeogi_gal_lae/api/vote/service/VoteService.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/api/vote/service/VoteService.java
@@ -40,26 +40,6 @@ public class VoteService {
     private final NotificationService notificationService;
 
     @Transactional
-    public synchronized void createVoteRoom(VoteRequest.createVoteRoomReq request) {
-        // 1. 여행 계획 ID로 TripPlan 조회
-        TripPlan tripPlan = tripPlanRepository.findById(request.getTripId())
-                .orElseThrow(() -> new BusinessException(ErrorCode.TRIP_PLAN_NOT_FOUND));
-
-        // 2. 기존 VoteRoom이 존재하는지 확인 (중복 생성 방지)
-        if (voteRoomRepository.findByTripPlanId(tripPlan.getId()).isPresent()) {
-            throw new BusinessException(ErrorCode.VOTE_ROOM_ALREADY_EXISTS);
-        }
-
-        // 3. 새로운 VoteRoom 생성 및 저장
-        VoteRoom voteRoom = new VoteRoom();
-        voteRoom.setTripPlan(tripPlan);
-        tripPlan.setStatus(Status.ONGOING); // 여행 계획을 '진행 중' 상태로 변경
-
-        voteRoomRepository.save(voteRoom);
-        tripPlanRepository.save(tripPlan);
-    }
-
-    @Transactional
     public void createVote(VoteRequest.createVoteReq request, String userEmail){
 
         // 유저 이메일로 검증

--- a/src/main/java/com/umc/yeogi_gal_lae/api/vote/service/VoteService.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/api/vote/service/VoteService.java
@@ -75,7 +75,7 @@ public class VoteService {
                         .type(VoteType.valueOf(request.getType().trim().toUpperCase()))   // 초기 타입 설정
                         .build()));
         // 투표 시작 알림 생성
-        notificationService.createStartNotification(tripPlan.getRoom().getName(), user.getUsername(), NotificationType.VOTE_START);
+        notificationService.createStartNotification(tripPlan.getRoom().getName(), user.getUsername(), user.getEmail(),NotificationType.VOTE_START);
 
         // 기존 투표 이력 확인
         Vote currentVote = user.getVote();

--- a/src/main/java/com/umc/yeogi_gal_lae/global/error/ErrorCode.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/global/error/ErrorCode.java
@@ -60,7 +60,10 @@ public enum ErrorCode implements BaseStatus {
     AI_TRIP_PLAN_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "50001", "여행 일정 생성에 실패했습니다."),
 
     // 투표방 오류
-    VOTE_ROOM_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "VOTE_400", "이미 존재하는 투표 방입니다.")
+    VOTE_ROOM_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "VOTE_400", "이미 존재하는 투표 방입니다."),
+
+    // 알림 오류
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION404", "알림을 찾을 수 없습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/umc/yeogi_gal_lae/global/success/SuccessCode.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/global/success/SuccessCode.java
@@ -50,6 +50,7 @@ public enum SuccessCode implements BaseStatus {
     NOTIFICATION_FETCH_OK(HttpStatus.OK, "NOTIFICATION_200", "알림 조회 성공"),
     NOTIFICATION_START_OK(HttpStatus.CREATED, "NOTIFICATION_201", "알림 시작 성공"),
     NOTIFICATION_END_OK(HttpStatus.OK, "NOTIFICATION_202", "알림 종료 성공"),
+    NOTIFICATION_READ_OK(HttpStatus.OK, "NOTIFICATION_203", "알림 읽음"),
 
 
     // AI Success


### PR DESCRIPTION
## #️⃣연관된 이슈

> #42 #72 
## 📝작업 내용

- 알림(Notification) 생성 시 이메일 저장 추가
  - 기존에는 사용자의 userName(이름)만 저장하여 알림을 생성했으나, 이메일(userEmail)도 저장하도록 수정.
  - 동명이인 문제 해결
  - 수정 내용:

    - Notification 엔티티에 userEmail 필드 추가.
    - NotificationService.createStartNotification() 및 createEndNotification()에서 userEmail을 함께 저장하도록 변경.
    - VoteService.createVote() 및 ValidVoteResultService에서 알림을 생성할 때 userEmail을 전달하도록 수정.
    
- 특정 사용자의 읽지 않은 알림 개수 조회를 사용자 이름이 아닌 이메일로 변경
  - 특정 알림을 읽음 처리할 때(PATCH /api/notifications/{id}/read), 읽음처리 하려하는 사용자가 해당 알림의 주인인지 확인하는 검증을 추가.
- 홈 화면에서 사용자가 읽지 않은 알림이 있는지 확인하는 API 추가 
- 특정 알림을 클릭하면 읽음 처리되도록 수정
  - 사용자가 알림을 클릭하면 해당 알림만 isRead = true로 변경되도록 수정.
- 여행 계획이 생성되어서 DB에 값이 저장될 때 동시에 여행 계획과 연관된 투표 방이 생성
- 원래 로그인된 사용자의 정보를 따로 불러와서 api 요청을 받아오지 않았지만 --> 사용자의 정보(이메일)를 기반으로 조회하거나 생성하는 api에서 로그인된 사용자의 정보를 받아서 요청을 받도록 수정.

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/69b4942c-6c26-4b54-b967-7b02f006d989)
![image](https://github.com/user-attachments/assets/13e5e13d-9639-4c44-91b9-4f61a8c549af)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
> 