### PR TITLE
[feat] 로그인 프론트의 로컬과 배포환경에 따른 동적 쿠키 설정

### DIFF
--- a/src/main/java/com/umc/yeogi_gal_lae/global/oauth/util/CookieUtil.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/global/oauth/util/CookieUtil.java
@@ -8,23 +8,33 @@ import java.util.Optional;
 
 public class CookieUtil {
 
-    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge, boolean isLocal) {
         Cookie cookie = new Cookie(name, value);
         cookie.setPath("/");
         cookie.setHttpOnly(true);
-        cookie.setSecure(false);  // HTTPS 사용 시 true 적용
+        cookie.setSecure(!isLocal);  // 로컬에서는 false, 배포에서는 true
         cookie.setMaxAge(maxAge);
-        cookie.setAttribute("SameSite", "None"); // 크로스사이트 요청 가능하게 설정
+
+        // 배포 환경에서는 크로스사이트 요청 가능하도록 설정
+        if (!isLocal) {
+            cookie.setAttribute("SameSite", "None");
+        } else {
+            cookie.setAttribute("SameSite", "Lax"); // 로컬에서는 기본값 설정
+        }
+
         response.addCookie(cookie);
     }
 
-    public static void deleteCookie(HttpServletResponse response, String name) {
+    public static void deleteCookie(HttpServletResponse response, String name, boolean isLocal) {
         Cookie cookie = new Cookie(name, null);
         cookie.setPath("/");
         cookie.setHttpOnly(true);
         cookie.setMaxAge(0);
+        cookie.setSecure(!isLocal);
+
         response.addCookie(cookie);
     }
+
 
     public static String getCookieValue(HttpServletRequest request, String name) {
         return Optional.ofNullable(request.getCookies())


### PR DESCRIPTION
## #️⃣연관된 이슈

> #129 

## 📝작업 내용

> 로그인 API에서 프론트의 로컬환경과 배포환경에서의 인가 코드 발급에 따른 쿠키 생성이 달라지도록 동적으로 구현했습니다.

### 스크린샷
![image](https://github.com/user-attachments/assets/fddbe693-c318-4e2a-b123-327c99bec8c9)
![다운로드 (2)](https://github.com/user-attachments/assets/156323e3-a3fc-469a-9776-8757ce486d69)
![다운로드 (1)](https://github.com/user-attachments/assets/a7e973d9-bb72-4e69-b605-a5579f39a4a0)
![다운로드](https://github.com/user-attachments/assets/3775b046-9a60-412f-be3a-cc140ab7649f)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
> 