### PR TITLE
[refactor] 방 정보 조회시 본인 제외

### DIFF
--- a/src/main/java/com/umc/yeogi_gal_lae/api/room/service/RoomService.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/api/room/service/RoomService.java
@@ -167,6 +167,7 @@ public class RoomService {
                         .roomId(room.getId())
                         .roomName(room.getName())
                         .members(room.getRoomMembers().stream()
+                                .filter(member -> !member.getUser().getId().equals(userId)) // 본인 제외
                                 .map(member -> new SimpleRoomMemberResponse(
                                         member.getUser().getId(),
                                         member.getUser().getProfileImage() // 프로필 이미지 추가


### PR DESCRIPTION

## 📝작업 내용

방 정보 조회시 본인 정보가 리스트나 프로필에 뜰 필요 없기 때문에 본인은 걸러지도록 했습니다 