### PR TITLE
[refactor] 방정보 조회시 본인만 있는 방의 정보 조회 안되는 오류 수정

### DIFF
--- a/src/main/java/com/umc/yeogi_gal_lae/api/room/service/RoomService.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/api/room/service/RoomService.java
@@ -167,10 +167,9 @@ public class RoomService {
                         .roomId(room.getId())
                         .roomName(room.getName())
                         .members(room.getRoomMembers().stream()
-                                .filter(member -> !member.getUser().getId().equals(userId)) // 본인 제외
                                 .map(member -> new SimpleRoomMemberResponse(
                                         member.getUser().getId(),
-                                        member.getUser().getProfileImage() // 프로필 이미지 추가
+                                        member.getUser().getId().equals(userId) ? null : member.getUser().getProfileImage() // 본인 프로필만 null 처리
                                 ))
                                 .collect(Collectors.toList()))
                         .build())


### PR DESCRIPTION
## 📝작업 내용

방정보조회에서 자신의 프로필을 안보내기 위해서 본인을 아예 응답에서 제외하는 방향으로 수정했는데, 본인만 있는 방의 정보를 조회할 수 없는 오류 발생함
프로필만 안보내도록 수정함 