### PR TITLE
[refactor] 방 멤버에 방장도 추가

### DIFF
--- a/src/main/java/com/umc/yeogi_gal_lae/api/room/service/RoomService.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/api/room/service/RoomService.java
@@ -53,6 +53,7 @@ public class RoomService {
 
         // 방 멤버 추가
         List<User> users = userRepository.findAllById(request.getUserIds());
+        users.add(master);  // 방장 추가
 
         List<RoomMember> newRoomMembers = users.stream()
                 .map(user -> RoomMemberConverter.fromRequest(room, user))

--- a/src/main/java/com/umc/yeogi_gal_lae/api/room/service/RoomService.java
+++ b/src/main/java/com/umc/yeogi_gal_lae/api/room/service/RoomService.java
@@ -53,7 +53,11 @@ public class RoomService {
 
         // 방 멤버 추가
         List<User> users = userRepository.findAllById(request.getUserIds());
-        users.add(master);  // 방장 추가
+
+        // 방장 추가
+        if (!users.contains(master)) {  // 중복 추가 방지
+            users.add(master);
+        }
 
         List<RoomMember> newRoomMembers = users.stream()
                 .map(user -> RoomMemberConverter.fromRequest(room, user))


### PR DESCRIPTION


## 📝작업 내용

방 리스트 조회시 사용자가 속한 방이 자신이 방장으로만 속해있는 경우 목업데이터가 나오고 리스트 조회시 본인이 방장인 방은 조회가 안되었습니다. 방장을 방 멤버에 추가하는 로직을 추가하여 해결했습니다. 

